### PR TITLE
Improve responsiveness

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,7 @@ function App() {
   };
 
   return (
-    <div className="min-h-screen bg-black text-green-300 font-mono p-8 flex items-start justify-center">
+    <div className="min-h-screen bg-black text-green-300 font-mono p-4 md:p-8 flex items-start justify-center">
       <div className="w-full max-w-3xl">
         <Header />
         <BalanceDisplay balance={balance} />

--- a/src/components/StockCard.jsx
+++ b/src/components/StockCard.jsx
@@ -1,11 +1,11 @@
 function StockCard({ stock, onBuy, onSell }) {
   return (
-    <div className="bg-black border border-green-500 p-4 mb-4 flex justify-between items-center font-mono">
+    <div className="bg-black border border-green-500 p-4 mb-4 flex flex-col sm:flex-row justify-between items-start sm:items-center font-mono">
       <div>
         <div className="text-green-300 text-lg">{stock.name}</div>
         <div className="text-blue-300">Price: {stock.price}₵</div>
       </div>
-      <div className="flex gap-2">
+      <div className="flex gap-2 mt-4 sm:mt-0">
         <button onClick={() => onBuy(stock.name)} className="bg-green-700 hover:bg-green-900 text-white px-3 py-1 rounded">
           Buy
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -8,15 +8,16 @@
   box-sizing: border-box;
 }
 
-html, body, #root {
+html,
+body,
+#root {
   margin: 0;
   padding: 0;
   width: 100%;
-  height: 100%;
+  min-height: 100%;
   background: #000;
   color: #0ff;
   font-family: 'Courier New', Courier, monospace;
-  overflow: hidden;
 }
 
 body {
@@ -101,16 +102,17 @@ button:focus-visible {
   --font-family: 'Courier New', Courier, monospace;
 }
 
-html, body, #root {
+html,
+body,
+#root {
   background: var(--bg-color);
   color: var(--text-color);
   font-family: var(--font-family);
   font-size: 1.1rem;
-  padding: 40px;
+  padding: 1rem;
   margin: 0;
-  height: 100%;
   width: 100%;
-  overflow: hidden;
+  min-height: 100%;
 }
 
 .terminal {


### PR DESCRIPTION
## Summary
- tweak global styles to remove fixed heights and padding
- adjust layout padding for small screens
- stack stock card buttons vertically on small screens
- ensure the project builds and lint passes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b344fb9b883299143815b9c024289