### PR TITLE
Add portfolio tracking to stock demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
+## Features
+
+- Demo stock trading interface with buy/sell buttons
+- Tracks your balance and stock holdings
+- Built with React and Tailwind CSS
+
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,17 +12,32 @@ function App() {
     { name: 'DuckWare 🦆', price: 80 },
     { name: 'ToasterInc 🔥', price: 200 },
   ]);
+  const [portfolio, setPortfolio] = useState({
+    'BananaCorp 🍌': 0,
+    'DuckWare 🦆': 0,
+    'ToasterInc 🔥': 0,
+  });
 
   const handleBuy = (stockName) => {
     const stock = stocks.find((s) => s.name === stockName);
     if (balance >= stock.price) {
       setBalance(balance - stock.price);
+      setPortfolio((prev) => ({
+        ...prev,
+        [stockName]: prev[stockName] + 1,
+      }));
     }
   };
 
   const handleSell = (stockName) => {
     const stock = stocks.find((s) => s.name === stockName);
-    setBalance(balance + stock.price);
+    if (portfolio[stockName] > 0) {
+      setBalance(balance + stock.price);
+      setPortfolio((prev) => ({
+        ...prev,
+        [stockName]: prev[stockName] - 1,
+      }));
+    }
   };
 
   return (
@@ -30,7 +45,12 @@ function App() {
       <div className="w-full max-w-3xl">
         <Header />
         <BalanceDisplay balance={balance} />
-        <StockList stocks={stocks} onBuy={handleBuy} onSell={handleSell} />
+        <StockList
+          stocks={stocks}
+          onBuy={handleBuy}
+          onSell={handleSell}
+          portfolio={portfolio}
+        />
         <Footer />
       </div>
     </div>

--- a/src/components/StockCard.jsx
+++ b/src/components/StockCard.jsx
@@ -1,9 +1,10 @@
-function StockCard({ stock, onBuy, onSell }) {
+function StockCard({ stock, onBuy, onSell, holdings }) {
   return (
     <div className="bg-black border border-green-500 p-4 mb-4 flex justify-between items-center font-mono">
       <div>
         <div className="text-green-300 text-lg">{stock.name}</div>
         <div className="text-blue-300">Price: {stock.price}₵</div>
+        <div className="text-yellow-300">Holdings: {holdings}</div>
       </div>
       <div className="flex gap-2">
         <button onClick={() => onBuy(stock.name)} className="bg-green-700 hover:bg-green-900 text-white px-3 py-1 rounded">

--- a/src/components/StockList.jsx
+++ b/src/components/StockList.jsx
@@ -1,10 +1,16 @@
 import StockCard from './StockCard';
 
-function StockList({ stocks, onBuy, onSell }) {
+function StockList({ stocks, onBuy, onSell, portfolio }) {
   return (
     <div>
       {stocks.map((stock) => (
-        <StockCard key={stock.name} stock={stock} onBuy={onBuy} onSell={onSell} />
+        <StockCard
+          key={stock.name}
+          stock={stock}
+          holdings={portfolio[stock.name] || 0}
+          onBuy={onBuy}
+          onSell={onSell}
+        />
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- track stock holdings in App state
- pass holding data to StockList and StockCard
- display holdings on each stock card
- document demo features in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686c18712ff0832989c965b5bd09fd0a