### PR TITLE
Add localStorage persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project uses Vite and React to showcase the early MVP for the 404Cache stock market game. Prices update automatically and you can buy or sell fictional stocks to watch your balance change.
 
+## Data Persistence
+
+Your balance and owned stock amounts are stored in **localStorage**, so your progress sticks around between browser sessions.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,8 +7,14 @@ import Footer from './components/Footer';
 import './index.css';
 
 function App() {
-  const [balance, setBalance] = useState(5000);
-  const [portfolio, setPortfolio] = useState({});
+  const [balance, setBalance] = useState(() => {
+    const stored = localStorage.getItem('balance');
+    return stored ? JSON.parse(stored) : 5000;
+  });
+  const [portfolio, setPortfolio] = useState(() => {
+    const stored = localStorage.getItem('portfolio');
+    return stored ? JSON.parse(stored) : {};
+  });
   const [stocks, setStocks] = useState([
     { name: 'BananaCorp 🍌', price: 120 },
     { name: 'DuckWare 🦆', price: 80 },
@@ -29,6 +35,14 @@ function App() {
     const id = setInterval(updateStockPrices, 5000);
     return () => clearInterval(id);
   }, []);
+
+  useEffect(() => {
+    localStorage.setItem('balance', JSON.stringify(balance));
+  }, [balance]);
+
+  useEffect(() => {
+    localStorage.setItem('portfolio', JSON.stringify(portfolio));
+  }, [portfolio]);
 
   const handleBuy = (stockName) => {
     const stock = stocks.find((s) => s.name === stockName);


### PR DESCRIPTION
## Summary
- store balance and portfolio values in localStorage so progress persists
- document the new persistence feature in the README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686c7072e7048329a59d44af2c3eb063