### PR TITLE
Add upgrade shop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # 404Cache Stock Market Demo
 
-This project uses Vite and React to showcase the early MVP for the 404Cache stock market game. Prices update automatically and you can buy or sell fictional stocks to watch your balance change. A running total of your portfolio value is displayed under your balance.
+This project uses Vite and React to showcase the early MVP for the 404Cache stock market game. Prices update automatically and you can buy or sell fictional stocks to watch your balance change. A running total of your portfolio value is displayed under your balance. A passive income system pays out every few seconds, and an upgrade shop lets you spend currency to increase that rate.
 
 ## Data Persistence
 
-Your balance and owned stock amounts are stored in **localStorage**, so your progress sticks around between browser sessions.
+Your balance, owned stock amounts, passive income rate, and purchased upgrades are stored in **localStorage**, so your progress sticks around between browser sessions.
 
 Currently, two official plugins are available:
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,11 +4,15 @@ import PortfolioValueDisplay from './components/PortfolioValueDisplay';
 import StockList from './components/StockList';
 import StockCount from './components/StockCount';
 import PassiveIncomeDisplay from './components/PassiveIncomeDisplay';
+import UpgradeShop from './components/UpgradeShop';
 import Header from './components/Header';
 import Footer from './components/Footer';
 import './index.css';
 
 function App() {
+  const upgrades = [
+    { id: 'upgrade_income', name: 'Faster Income', cost: 1000, bonus: 1 },
+  ];
   const [balance, setBalance] = useState(() => {
     const stored = localStorage.getItem('balance');
     return stored ? JSON.parse(stored) : 5000;
@@ -17,7 +21,14 @@ function App() {
     const stored = localStorage.getItem('portfolio');
     return stored ? JSON.parse(stored) : {};
   });
-  const [passiveRate] = useState(5); // currency earned every 10 seconds
+  const [passiveRate, setPassiveRate] = useState(() => {
+    const stored = localStorage.getItem('passiveRate');
+    return stored ? JSON.parse(stored) : 5;
+  });
+  const [purchasedUpgrades, setPurchasedUpgrades] = useState(() => {
+    const stored = localStorage.getItem('purchasedUpgrades');
+    return stored ? JSON.parse(stored) : [];
+  });
   const [passiveEarned, setPassiveEarned] = useState(() => {
     const stored = localStorage.getItem('passiveEarned');
     return stored ? JSON.parse(stored) : 0;
@@ -63,6 +74,24 @@ function App() {
     localStorage.setItem('passiveEarned', JSON.stringify(passiveEarned));
   }, [passiveEarned]);
 
+  useEffect(() => {
+    localStorage.setItem('passiveRate', JSON.stringify(passiveRate));
+  }, [passiveRate]);
+
+  useEffect(() => {
+    localStorage.setItem('purchasedUpgrades', JSON.stringify(purchasedUpgrades));
+  }, [purchasedUpgrades]);
+
+  const handlePurchaseUpgrade = (id) => {
+    const upgrade = upgrades.find((u) => u.id === id);
+    if (!upgrade) return;
+    if (balance >= upgrade.cost && !purchasedUpgrades.includes(id)) {
+      setBalance((b) => b - upgrade.cost);
+      setPurchasedUpgrades((u) => [...u, id]);
+      setPassiveRate((r) => r + upgrade.bonus);
+    }
+  };
+
   const handleBuy = (stockName) => {
     const stock = stocks.find((s) => s.name === stockName);
     if (balance >= stock.price) {
@@ -87,6 +116,11 @@ function App() {
         <PassiveIncomeDisplay rate={passiveRate} earned={passiveEarned} />
         <PortfolioValueDisplay stocks={stocks} portfolio={portfolio} />
         <StockCount count={stocks.length} />
+        <UpgradeShop
+          upgrades={upgrades}
+          purchased={purchasedUpgrades}
+          onPurchase={handlePurchaseUpgrade}
+        />
         <StockList
           stocks={stocks}
           portfolio={portfolio}

--- a/src/components/UpgradeShop.jsx
+++ b/src/components/UpgradeShop.jsx
@@ -1,0 +1,23 @@
+function UpgradeShop({ upgrades, purchased, onPurchase }) {
+  return (
+    <div className="mb-4">
+      <h2 className="text-purple-400 mb-2 font-bold">Upgrade Shop</h2>
+      {upgrades.map((u) => (
+        <div key={u.id} className="flex justify-between mb-2">
+          <span>
+            {u.name} - Cost: {u.cost}₵
+          </span>
+          <button
+            onClick={() => onPurchase(u.id)}
+            disabled={purchased.includes(u.id)}
+            className="bg-purple-700 hover:bg-purple-900 text-white px-2 py-1 rounded disabled:opacity-50"
+          >
+            {purchased.includes(u.id) ? 'Purchased' : 'Buy'}
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default UpgradeShop;


### PR DESCRIPTION
## Summary
- add an upgrade shop component so players can buy faster passive income
- persist passive rate and purchased upgrades in localStorage
- document the upgrade system in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c782daa948329a169d54a5b1d1b2a