### PR TITLE
Add reset game option

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -108,6 +108,24 @@ function App() {
     }
   };
 
+  const resetGame = () => {
+    setBalance(5000);
+    setPortfolio({});
+    setPassiveRate(5);
+    setPurchasedUpgrades([]);
+    setPassiveEarned(0);
+    setStocks([
+      { name: 'BananaCorp \ud83c\udf4c', price: 120 },
+      { name: 'DuckWare \ud83e\udd86', price: 80 },
+      { name: 'ToasterInc \ud83d\udd25', price: 200 },
+    ]);
+    localStorage.removeItem('balance');
+    localStorage.removeItem('portfolio');
+    localStorage.removeItem('passiveRate');
+    localStorage.removeItem('purchasedUpgrades');
+    localStorage.removeItem('passiveEarned');
+  };
+
   return (
     <div className="min-h-screen bg-black text-green-300 font-mono p-4 md:p-8 flex items-start justify-center">
       <div className="w-full max-w-3xl">
@@ -127,7 +145,7 @@ function App() {
           onBuy={handleBuy}
           onSell={handleSell}
         />
-        <Footer />
+        <Footer onReset={resetGame} />
       </div>
     </div>
   );

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,17 @@
-function Footer() {
+function Footer({ onReset }) {
   return (
     <footer className="mt-8 text-center text-green-500 text-sm">
       © 2025 404Cache. All trades are fictional.
+      {onReset && (
+        <div className="mt-2">
+          <button
+            onClick={onReset}
+            className="bg-red-700 hover:bg-red-900 text-white px-3 py-1 rounded"
+          >
+            Reset Game
+          </button>
+        </div>
+      )}
     </footer>
   );
 }


### PR DESCRIPTION
## Summary
- add an optional `onReset` prop to `Footer` and display a **Reset Game** button
- add `resetGame` function in `App` and pass it to `Footer`
- ensure build and lint pass

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c79f781a88329bbe9db204b8a6520