### PR TITLE
Add portfolio history chart

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import PortfolioChart from './components/PortfolioChart';
 import BalanceDisplay from './components/BalanceDisplay';
 import PortfolioValueDisplay from './components/PortfolioValueDisplay';
 import StockList from './components/StockList';
@@ -27,6 +28,10 @@ function App() {
     { name: 'DuckWare 🦆', price: 80 },
     { name: 'ToasterInc 🔥', price: 200 },
   ]);
+  const [history, setHistory] = useState(() => {
+    const stored = localStorage.getItem('netWorthHistory');
+    return stored ? JSON.parse(stored) : [];
+  });
 
   const updateStockPrices = () => {
     setStocks((prev) =>
@@ -63,6 +68,19 @@ function App() {
     localStorage.setItem('passiveEarned', JSON.stringify(passiveEarned));
   }, [passiveEarned]);
 
+  useEffect(() => {
+    const portfolioValue = stocks.reduce((sum, stock) => {
+      const owned = portfolio[stock.name] || 0;
+      return sum + owned * stock.price;
+    }, 0);
+    const netWorth = balance + portfolioValue;
+    setHistory((h) => {
+      const updated = [...h, netWorth].slice(-20);
+      localStorage.setItem('netWorthHistory', JSON.stringify(updated));
+      return updated;
+    });
+  }, [stocks, balance, portfolio]);
+
   const handleBuy = (stockName) => {
     const stock = stocks.find((s) => s.name === stockName);
     if (balance >= stock.price) {
@@ -86,6 +104,7 @@ function App() {
         <BalanceDisplay balance={balance} />
         <PassiveIncomeDisplay rate={passiveRate} earned={passiveEarned} />
         <PortfolioValueDisplay stocks={stocks} portfolio={portfolio} />
+        <PortfolioChart data={history} />
         <StockCount count={stocks.length} />
         <StockList
           stocks={stocks}

--- a/src/components/PortfolioChart.jsx
+++ b/src/components/PortfolioChart.jsx
@@ -1,0 +1,23 @@
+function PortfolioChart({ data }) {
+  if (!data || data.length < 2) return null;
+
+  const width = 300;
+  const height = 100;
+  const max = Math.max(...data);
+  const min = Math.min(...data);
+  const points = data
+    .map((d, i) => {
+      const x = (i / (data.length - 1)) * width;
+      const y = height - ((d - min) / (max - min || 1)) * height;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <svg width={width} height={height} className="mt-4">
+      <polyline points={points} fill="none" stroke="currentColor" strokeWidth="2" />
+    </svg>
+  );
+}
+
+export default PortfolioChart;


### PR DESCRIPTION
## Summary
- add new `PortfolioChart` component that renders an SVG line graph
- track net worth history and persist it in local storage
- render the chart in `App.jsx` under portfolio value

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c79967484832990dfe0b91e1ab4ea