### PR TITLE
Improve stock listing layout

### DIFF
--- a/src/components/StockCard.jsx
+++ b/src/components/StockCard.jsx
@@ -1,6 +1,6 @@
 function StockCard({ stock, owned, balance, onBuy, onSell }) {
   return (
-    <div className="bg-black border border-green-500 p-4 mb-4 flex flex-col sm:flex-row justify-between items-start sm:items-center font-mono">
+    <div className="bg-gradient-to-br from-gray-900 to-gray-800 border border-green-500 p-4 mb-4 sm:mb-0 flex flex-col sm:flex-row justify-between items-start sm:items-center font-mono rounded shadow-lg">
       <div>
         <div className="text-green-300 text-lg">{stock.name}</div>
         <div className="text-blue-300 flex items-center">

--- a/src/components/StockList.jsx
+++ b/src/components/StockList.jsx
@@ -2,7 +2,7 @@ import StockCard from './StockCard';
 
 function StockList({ stocks, portfolio, balance, onBuy, onSell }) {
   return (
-    <div>
+    <div className="grid gap-4 sm:grid-cols-2">
       {stocks.map((stock) => (
         <StockCard
           key={stock.name}


### PR DESCRIPTION
## Summary
- tweak `StockCard` styling
- display stocks in a two-column grid on wide screens

## Testing
- `npm run lint`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686daeda5778832980ded690699c338a