### PR TITLE
Add net worth display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 404Cache Stock Market Demo
 
-This project uses Vite and React to showcase the early MVP for the 404Cache stock market game. Prices update automatically and you can buy or sell fictional stocks to watch your balance change. A running total of your portfolio value is displayed under your balance. A passive income system pays out every few seconds, and an upgrade shop lets you spend currency to increase that rate.
+This project uses Vite and React to showcase the early MVP for the 404Cache stock market game. Prices update automatically and you can buy or sell fictional stocks to watch your balance change. A running total of your portfolio value is displayed under your balance, along with a new net worth readout that sums balance and portfolio value. A passive income system pays out every few seconds, and an upgrade shop lets you spend currency to increase that rate.
 
 ## Data Persistence
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import PortfolioChart from './components/PortfolioChart';
 import BalanceDisplay from './components/BalanceDisplay';
 import PortfolioValueDisplay from './components/PortfolioValueDisplay';
+import NetWorthDisplay from './components/NetWorthDisplay';
 import StockList from './components/StockList';
 import StockCount from './components/StockCount';
 import PassiveIncomeDisplay from './components/PassiveIncomeDisplay';
@@ -203,6 +204,7 @@ function App() {
         <LoginStreakDisplay streak={loginStreak} />
         <PassiveIncomeDisplay rate={passiveRate} earned={passiveEarned} />
         <PortfolioValueDisplay stocks={stocks} portfolio={portfolio} />
+        <NetWorthDisplay balance={balance} stocks={stocks} portfolio={portfolio} />
         <PortfolioChart data={history} />
         <StockCount count={stocks.length} />
         <UpgradeShop

--- a/src/components/NetWorthDisplay.jsx
+++ b/src/components/NetWorthDisplay.jsx
@@ -1,0 +1,15 @@
+function NetWorthDisplay({ balance, stocks, portfolio }) {
+  const totalStocksValue = stocks.reduce((sum, stock) => {
+    const owned = portfolio[stock.name] || 0;
+    return sum + owned * stock.price;
+  }, 0);
+  const netWorth = balance + totalStocksValue;
+
+  return (
+    <div className="mb-4 text-teal-400">
+      Net Worth: <span className="font-bold">{netWorth}\u00A2</span>
+    </div>
+  );
+}
+
+export default NetWorthDisplay;


### PR DESCRIPTION
## Summary
- show player net worth by combining balance and portfolio value
- document the new feature in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686db6def0308329801c2635502d1f24