### PR TITLE
Add confetti and animation when buying stocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "404cache",
       "version": "0.0.0",
       "dependencies": {
+        "canvas-confetti": "^1.9.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -1891,6 +1892,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "canvas-confetti": "^1.9.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import Header from './components/Header';
 import Footer from './components/Footer';
 import ToastContainer from './components/ToastContainer';
 import LoginStreakDisplay from './components/LoginStreakDisplay';
+import confetti from "canvas-confetti";
 import './index.css';
 
 function App() {
@@ -161,6 +162,7 @@ function App() {
       setBalance((b) => b - stock.price);
       setPortfolio((p) => ({ ...p, [stockName]: (p[stockName] || 0) + 1 }));
       addToast(`Bought 1 ${stockName} for ${stock.price}\u00A2`);
+      confetti({ particleCount: 80, spread: 70, origin: { y: 0.6 } });
     } else {
       addToast(`Not enough balance to buy ${stockName}`);
     }

--- a/src/components/StockCard.jsx
+++ b/src/components/StockCard.jsx
@@ -1,4 +1,14 @@
+import { useState } from 'react';
+
 function StockCard({ stock, owned, balance, onBuy, onSell }) {
+  const [bouncing, setBouncing] = useState(false);
+
+  const handleBuy = () => {
+    setBouncing(true);
+    onBuy(stock.name);
+    setTimeout(() => setBouncing(false), 300);
+  };
+
   return (
     <div className="bg-gradient-to-br from-gray-900 to-gray-800 border border-green-500 p-4 mb-4 sm:mb-0 flex flex-col sm:flex-row justify-between items-start sm:items-center font-mono rounded shadow-lg">
       <div>
@@ -20,8 +30,8 @@ function StockCard({ stock, owned, balance, onBuy, onSell }) {
       </div>
       <div className="flex gap-2 mt-4 sm:mt-0">
         <button
-          onClick={() => onBuy(stock.name)}
-          className="bg-green-700 hover:bg-green-900 text-white px-3 py-1 rounded disabled:opacity-50"
+          onClick={handleBuy}
+          className={`bg-green-700 hover:bg-green-900 text-white px-3 py-1 rounded disabled:opacity-50 ${bouncing ? 'animate-bounce' : ''}`}
           disabled={balance < stock.price}
         >
           Buy


### PR DESCRIPTION
## Summary
- add `canvas-confetti` dependency
- trigger confetti burst in `handleBuy`
- animate buy button with a bounce effect

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686db6feb0ac8329ba115f070223bf86