### PR TITLE
Add Layout component and retro style

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,8 @@ import Header from './components/Header';
 import Footer from './components/Footer';
 import ToastContainer from './components/ToastContainer';
 import LoginStreakDisplay from './components/LoginStreakDisplay';
+import Layout from './components/Layout';
+import WindowFrame from './components/WindowFrame';
 import confetti from "canvas-confetti";
 import './index.css';
 
@@ -199,8 +201,8 @@ function App() {
   };
 
   return (
-    <div className="min-h-screen bg-black text-green-300 font-mono p-4 md:p-8 flex items-start justify-center">
-      <div className="w-full max-w-3xl space-y-6">
+    <Layout>
+      <div className="space-y-6">
         <Header />
         <BalanceDisplay balance={balance} />
         <LoginStreakDisplay streak={loginStreak} />
@@ -209,22 +211,26 @@ function App() {
         <NetWorthDisplay balance={balance} stocks={stocks} portfolio={portfolio} />
         <PortfolioChart data={history} />
         <StockCount count={stocks.length} />
-        <UpgradeShop
-          upgrades={upgrades}
-          purchased={purchasedUpgrades}
-          onPurchase={handlePurchaseUpgrade}
-        />
-        <StockList
-          stocks={stocks}
-          portfolio={portfolio}
-          balance={balance}
-          onBuy={handleBuy}
-          onSell={handleSell}
-        />
+        <WindowFrame title="Upgrades">
+          <UpgradeShop
+            upgrades={upgrades}
+            purchased={purchasedUpgrades}
+            onPurchase={handlePurchaseUpgrade}
+          />
+        </WindowFrame>
+        <WindowFrame title="Market">
+          <StockList
+            stocks={stocks}
+            portfolio={portfolio}
+            balance={balance}
+            onBuy={handleBuy}
+            onSell={handleSell}
+          />
+        </WindowFrame>
         <Footer onReset={resetGame} />
         <ToastContainer toasts={toasts} />
       </div>
-    </div>
+    </Layout>
   );
 }
 

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+function Layout({ children }) {
+  return (
+    <div className="min-h-screen bg-black text-green-300 font-mono p-4 md:p-8 crt-effect">
+      <div className="max-w-3xl mx-auto">
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export default Layout

--- a/src/components/WindowFrame.jsx
+++ b/src/components/WindowFrame.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+function WindowFrame({ title, children }) {
+  return (
+    <div className="border border-green-400 bg-black/70 rounded shadow-lg mb-4">
+      <div className="flex items-center justify-between bg-green-700 text-black px-2 py-1">
+        <span className="font-bold">{title}</span>
+        <div className="space-x-1">
+          <span className="inline-block w-3 h-3 bg-red-500 rounded-full" />
+          <span className="inline-block w-3 h-3 bg-yellow-500 rounded-full" />
+          <span className="inline-block w-3 h-3 bg-green-500 rounded-full" />
+        </div>
+      </div>
+      <div className="p-4">
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export default WindowFrame

--- a/src/index.css
+++ b/src/index.css
@@ -17,7 +17,7 @@ body,
   min-height: 100%;
   background: radial-gradient(circle at 50% 0, #022, #000);
   color: #0ff;
-  font-family: 'Press Start 2P', monospace;
+  font-family: 'Share Tech Mono', monospace;
 }
 
 body {
@@ -99,7 +99,7 @@ button:focus-visible {
 :root {
   --bg-color: radial-gradient(circle at 50% 0, #022, #000);
   --text-color: #0ff;
-  --font-family: 'Press Start 2P', monospace;
+  --font-family: 'Share Tech Mono', monospace;
 }
 
 html,
@@ -157,4 +157,31 @@ body,
   margin-top: 40px;
   font-size: 0.9rem;
   color: #888;
+}
+
+.crt-effect {
+  position: relative;
+  overflow: hidden;
+}
+.crt-effect::before {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(
+    rgba(255, 255, 255, 0.05) 50%,
+    transparent 50%
+  );
+  background-size: 100% 2px;
+  mix-blend-mode: overlay;
+  animation: scanlines 1s steps(60) infinite;
+}
+
+@keyframes scanlines {
+  0% {
+    background-position-y: 0;
+  }
+  100% {
+    background-position-y: 2px;
+  }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,11 @@
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        mono: ['"Share Tech Mono"', 'monospace'],
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- add global `Layout` wrapper with CRT background
- implement reusable `WindowFrame` styled like old-school OS windows
- switch to Share Tech Mono font across the site
- expose CRT scanline effect in CSS
- refactor `App.jsx` to use new components
- update Tailwind config to apply font

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686db973bf80832987696178c60a6662