### PR TITLE
Improve responsive layout

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -2,8 +2,8 @@ import React from 'react'
 
 function Layout({ children }) {
   return (
-    <div className="min-h-screen bg-black text-green-300 font-mono p-4 md:p-8 crt-effect">
-      <div className="max-w-3xl mx-auto">
+    <div className="min-h-screen bg-black text-green-300 font-mono px-4 py-4 sm:px-6 sm:py-6 lg:px-8 lg:py-8 crt-effect">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
         {children}
       </div>
     </div>

--- a/src/components/PortfolioChart.jsx
+++ b/src/components/PortfolioChart.jsx
@@ -31,7 +31,12 @@ function PortfolioChart({ data }) {
   });
 
   return (
-    <svg width={width} height={height + padding} className="mt-4 text-green-400">
+    <div className="overflow-x-auto">
+      <svg
+        width={width}
+        height={height + padding}
+        className="mt-4 text-green-400 min-w-[500px] w-full"
+      >
       <defs>
         <linearGradient id="chart-gradient" x1="0" y1="0" x2="0" y2="1">
           <stop offset="0%" stopColor="rgba(34,197,94,0.5)" />
@@ -57,7 +62,8 @@ function PortfolioChart({ data }) {
         <path d={areaPath} fill="url(#chart-gradient)" />
         <path d={linePath} fill="none" stroke="currentColor" strokeWidth="2" />
       </g>
-    </svg>
+      </svg>
+    </div>
   );
 }
 

--- a/src/components/StockList.jsx
+++ b/src/components/StockList.jsx
@@ -2,7 +2,7 @@ import StockCard from './StockCard';
 
 function StockList({ stocks, portfolio, balance, onBuy, onSell }) {
   return (
-    <div className="grid gap-4 sm:grid-cols-2">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 sm:gap-6">
       {stocks.map((stock) => (
         <StockCard
           key={stock.name}

--- a/src/components/WindowFrame.jsx
+++ b/src/components/WindowFrame.jsx
@@ -11,7 +11,7 @@ function WindowFrame({ title, children }) {
           <span className="inline-block w-3 h-3 bg-green-500 rounded-full" />
         </div>
       </div>
-      <div className="p-4">
+      <div className="p-4 sm:p-6 lg:p-8">
         {children}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- tweak Layout padding for mobile-friendly spacing
- let StockList scale through multiple breakpoints
- allow WindowFrame inner padding to adapt with screen size
- wrap PortfolioChart in an `overflow-x-auto` container

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686dbaab808083299f930e0d36759c88