### PR TITLE
Add CLI-style sidebar with extra tools

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import Footer from './components/Footer';
 import ToastContainer from './components/ToastContainer';
 import LoginStreakDisplay from './components/LoginStreakDisplay';
 import Layout from './components/Layout';
+import Sidebar from './components/Sidebar';
 import WindowFrame from './components/WindowFrame';
 import confetti from "canvas-confetti";
 import './index.css';
@@ -200,8 +201,46 @@ function App() {
     localStorage.removeItem('passiveEarned');
   };
 
+  const portfolioValue = stocks.reduce((sum, stock) => {
+    const owned = portfolio[stock.name] || 0;
+    return sum + owned * stock.price;
+  }, 0);
+  const netWorth = balance + portfolioValue;
+
+  const handleRandomBuy = () => {
+    const random = stocks[Math.floor(Math.random() * stocks.length)];
+    if (random) handleBuy(random.name);
+  };
+
+  const handleSellAll = () => {
+    let earned = 0;
+    const newPortfolio = { ...portfolio };
+    stocks.forEach((s) => {
+      const count = newPortfolio[s.name] || 0;
+      if (count > 0) {
+        earned += count * s.price;
+        newPortfolio[s.name] = 0;
+      }
+    });
+    if (earned > 0) {
+      setPortfolio(newPortfolio);
+      setBalance((b) => b + earned);
+      addToast(`Sold all stock for ${earned}\u00A2`);
+    }
+  };
+
   return (
-    <Layout>
+    <Layout
+      sidebar={
+        <Sidebar
+          balance={balance}
+          netWorth={netWorth}
+          onRandomBuy={handleRandomBuy}
+          onSellAll={handleSellAll}
+          onReset={resetGame}
+        />
+      }
+    >
       <div className="space-y-6">
         <Header />
         <BalanceDisplay balance={balance} />

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,10 +1,11 @@
 import React from 'react'
 
-function Layout({ children }) {
+function Layout({ children, sidebar }) {
   return (
-    <div className="min-h-screen bg-black text-green-300 font-mono p-4 md:p-8 crt-effect">
-      <div className="max-w-3xl mx-auto">
-        {children}
+    <div className="min-h-screen flex bg-black text-green-300 font-mono crt-effect">
+      {sidebar}
+      <div className="flex-1 p-4 md:p-8">
+        <div className="max-w-3xl mx-auto">{children}</div>
       </div>
     </div>
   )

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+
+function Sidebar({ balance, netWorth, onRandomBuy, onSellAll, onReset }) {
+  return (
+    <aside className="hidden lg:block w-56 bg-black/80 border-r border-green-600 p-4 font-mono text-green-300">
+      <h2 className="text-green-400 mb-3">&gt; Tools</h2>
+      <div className="space-y-2 text-sm">
+        <div>Balance: {balance}₵</div>
+        <div>Net Worth: {netWorth}₵</div>
+        <button
+          onClick={onRandomBuy}
+          className="w-full bg-green-700 hover:bg-green-900 text-white px-2 py-1 rounded"
+        >
+          Random Buy
+        </button>
+        <button
+          onClick={onSellAll}
+          className="w-full bg-yellow-700 hover:bg-yellow-900 text-white px-2 py-1 rounded"
+        >
+          Sell All
+        </button>
+        <button
+          onClick={onReset}
+          className="w-full bg-red-700 hover:bg-red-900 text-white px-2 py-1 rounded"
+        >
+          Reset
+        </button>
+      </div>
+    </aside>
+  )
+}
+
+export default Sidebar


### PR DESCRIPTION
## Summary
- add new `Sidebar` component styled like a terminal window
- update `Layout` to support an optional sidebar element
- show sidebar in `App` with quick actions and stats

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686dbb2f66288329bf1c2b531f8f90de