### PR TITLE
Add more stocks and improve layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 404Cache Stock Market Demo
 
-This project uses Vite and React to showcase the early MVP for the 404Cache stock market game. Prices update automatically and you can buy or sell fictional stocks to watch your balance change. A running total of your portfolio value is displayed under your balance, along with a new net worth readout that sums balance and portfolio value. A passive income system pays out every few seconds, and an upgrade shop lets you spend currency to increase that rate.
+This project uses Vite and React to showcase the early MVP for the 404Cache stock market game. Prices update automatically and you can buy or sell a collection of six playful stocks to watch your balance change. A running total of your portfolio value is displayed under your balance, along with a new net worth readout that sums balance and portfolio value. A passive income system pays out every few seconds, and an upgrade shop lets you spend currency to increase that rate.
 
 ## Data Persistence
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,6 +44,9 @@ function App() {
     { name: 'BananaCorp \ud83c\udf4c', price: 120, prevPrice: 120 },
     { name: 'DuckWare \ud83e\udd86', price: 80, prevPrice: 80 },
     { name: 'ToasterInc \ud83d\udd25', price: 200, prevPrice: 200 },
+    { name: 'PixelPets \ud83d\udc31', price: 50, prevPrice: 50 },
+    { name: 'RoboDudes \ud83e\udd16', price: 150, prevPrice: 150 },
+    { name: 'CryptoNoggin \ud83d\udc8e', price: 300, prevPrice: 300 },
   ]);
   const [history, setHistory] = useState(() => {
     const stored = localStorage.getItem('netWorthHistory');
@@ -192,6 +195,9 @@ function App() {
       { name: 'BananaCorp \ud83c\udf4c', price: 120 },
       { name: 'DuckWare \ud83e\udd86', price: 80 },
       { name: 'ToasterInc \ud83d\udd25', price: 200 },
+      { name: 'PixelPets \ud83d\udc31', price: 50 },
+      { name: 'RoboDudes \ud83e\udd16', price: 150 },
+      { name: 'CryptoNoggin \ud83d\udc8e', price: 300 },
     ]);
     localStorage.removeItem('balance');
     localStorage.removeItem('portfolio');

--- a/src/components/StockCard.jsx
+++ b/src/components/StockCard.jsx
@@ -10,9 +10,9 @@ function StockCard({ stock, owned, balance, onBuy, onSell }) {
   };
 
   return (
-    <div className="bg-gradient-to-br from-gray-900 to-gray-800 border border-green-500 p-4 mb-4 sm:mb-0 flex flex-col sm:flex-row justify-between items-start sm:items-center font-mono rounded shadow-lg">
+    <div className="bg-gradient-to-br from-gray-900 to-gray-800 border border-green-500 p-4 mb-4 sm:mb-0 flex flex-col sm:flex-row justify-between items-start sm:items-center font-mono rounded shadow-lg shadow-green-700/30 transition-transform hover:scale-105">
       <div>
-        <div className="text-green-300 text-lg">{stock.name}</div>
+        <div className="text-green-300 text-xl font-bold">{stock.name}</div>
         <div className="text-blue-300 flex items-center">
           Price: {stock.price}₵
           {stock.price !== stock.prevPrice && (

--- a/src/components/StockList.jsx
+++ b/src/components/StockList.jsx
@@ -2,7 +2,7 @@ import StockCard from './StockCard';
 
 function StockList({ stocks, portfolio, balance, onBuy, onSell }) {
   return (
-    <div className="grid gap-4 sm:grid-cols-2">
+    <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
       {stocks.map((stock) => (
         <StockCard
           key={stock.name}


### PR DESCRIPTION
## Summary
- expand stock list with additional options
- enhance stock card styling and grid layout
- mention six playful stocks in README

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686dbbb1e3608329ab4f84ea35fd6703