### PR TITLE
Add profile stats section

### DIFF
--- a/src/components/ProfileStats.jsx
+++ b/src/components/ProfileStats.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { getItem } from '../lib/storage';
+
+function ProfileStats() {
+  const [stats, setStats] = useState(null);
+
+  useEffect(() => {
+    const balance = getItem('balance') ?? 0;
+    const passiveRate = getItem('passiveRate') ?? 5;
+    const passiveEarned = getItem('passiveEarned') ?? 0;
+    const loginStreak = getItem('loginStreak') ?? 1;
+    const purchasedUpgrades = getItem('purchasedUpgrades') ?? [];
+    const history = getItem('netWorthHistory') ?? [];
+
+    const highestNetWorth =
+      history.length > 0 ? Math.max(...history) : balance;
+    const lastNetWorth =
+      history.length > 0 ? history[history.length - 1] : balance;
+
+    setStats({
+      balance,
+      passiveRate,
+      passiveEarned,
+      loginStreak,
+      upgrades: purchasedUpgrades.length,
+      highestNetWorth,
+      lastNetWorth,
+    });
+  }, []);
+
+  if (!stats) return null;
+
+  return (
+    <div className="text-left mx-auto max-w-xs space-y-2">
+      <div>Balance: {stats.balance}₵</div>
+      <div>Net Worth: {stats.lastNetWorth}₵</div>
+      <div>Highest Net Worth: {stats.highestNetWorth}₵</div>
+      <div>Passive Rate: {stats.passiveRate}₵ / 10 sec</div>
+      <div>Total Passive Earned: {stats.passiveEarned}₵</div>
+      <div>Upgrades Purchased: {stats.upgrades}</div>
+      <div>
+        Login Streak: {stats.loginStreak} day{stats.loginStreak !== 1 ? 's' : ''}
+      </div>
+    </div>
+  );
+}
+
+export default ProfileStats;

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,11 +1,12 @@
 import Layout from '../components/Layout';
+import ProfileStats from '../components/ProfileStats';
 
 function Profile() {
   return (
     <Layout>
       <div className="text-center text-green-400 mt-10">
         <h2 className="text-3xl mb-4">Profile</h2>
-        <p>Your profile details will live here.</p>
+        <ProfileStats />
       </div>
     </Layout>
   );


### PR DESCRIPTION
## Summary
- introduce `ProfileStats` component to show local stats
- display `ProfileStats` on the Profile page

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686dc928cf148329acf428cf5066b3a4