### PR TITLE
Fix sidebar visibility and adjust buy button animation

### DIFF
--- a/src/components/StockCard.jsx
+++ b/src/components/StockCard.jsx
@@ -31,7 +31,7 @@ function StockCard({ stock, owned, balance, onBuy, onSell }) {
       <div className="flex gap-2 mt-4 sm:mt-0">
         <button
           onClick={handleBuy}
-          className={`bg-green-700 hover:bg-green-900 text-white px-3 py-1 rounded disabled:opacity-50 ${bouncing ? 'animate-bounce' : ''}`}
+          className={`bg-green-700 hover:bg-green-900 text-white px-3 py-1 rounded disabled:opacity-50 ${bouncing ? 'animate-bounce-small' : ''}`}
           disabled={balance < stock.price}
         >
           Buy

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -12,6 +12,7 @@ import Footer from '../components/Footer';
 import ToastContainer from '../components/ToastContainer';
 import LoginStreakDisplay from '../components/LoginStreakDisplay';
 import Layout from '../components/Layout';
+import Sidebar from '../components/Sidebar';
 import WindowFrame from '../components/WindowFrame';
 import confetti from "canvas-confetti";
 import { getItem, setItem, removeItem } from "../lib/storage";
@@ -200,8 +201,46 @@ function Dashboard() {
     removeItem('passiveEarned');
   };
 
+  const portfolioValue = stocks.reduce((sum, stock) => {
+    const owned = portfolio[stock.name] || 0;
+    return sum + owned * stock.price;
+  }, 0);
+  const netWorth = balance + portfolioValue;
+
+  const handleRandomBuy = () => {
+    const random = stocks[Math.floor(Math.random() * stocks.length)];
+    if (random) handleBuy(random.name);
+  };
+
+  const handleSellAll = () => {
+    let earned = 0;
+    const newPortfolio = { ...portfolio };
+    stocks.forEach((s) => {
+      const count = newPortfolio[s.name] || 0;
+      if (count > 0) {
+        earned += count * s.price;
+        newPortfolio[s.name] = 0;
+      }
+    });
+    if (earned > 0) {
+      setPortfolio(newPortfolio);
+      setBalance((b) => b + earned);
+      addToast(`Sold all stock for ${earned}\u00A2`);
+    }
+  };
+
   return (
-    <Layout>
+    <Layout
+      sidebar={
+        <Sidebar
+          balance={balance}
+          netWorth={netWorth}
+          onRandomBuy={handleRandomBuy}
+          onSellAll={handleSellAll}
+          onReset={resetGame}
+        />
+      }
+    >
       <div className="space-y-6">
         <Header />
         <BalanceDisplay balance={balance} />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,21 @@ export default {
       fontFamily: {
         mono: ['"Share Tech Mono"', 'monospace'],
       },
+      keyframes: {
+        'bounce-small': {
+          '0%, 100%': {
+            transform: 'translateY(-10%)',
+            animationTimingFunction: 'cubic-bezier(0.8,0,1,1)',
+          },
+          '50%': {
+            transform: 'translateY(0)',
+            animationTimingFunction: 'cubic-bezier(0,0,0.2,1)',
+          },
+        },
+      },
+      animation: {
+        'bounce-small': 'bounce-small 0.5s',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- restore sidebar usage in Dashboard page
- add random buy and bulk sell helpers
- create smaller bounce animation and use it on buy button

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686dc9bf463c8329bbdfaa617807e19a