### PR TITLE
Add high score tracker to Popup Frenzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Currently, two official plugins are available:
 ## Minigames
 
 Visit the `/minigames` page to play **Pop-up Frenzy**. Close as many pop-up windows as possible in 20 seconds to earn extra coins that are automatically added to your balance.
+Your best score is now saved locally and shown below the start button.
 
 ## Stock Search
 

--- a/src/components/HighScoreDisplay.jsx
+++ b/src/components/HighScoreDisplay.jsx
@@ -1,0 +1,8 @@
+function HighScoreDisplay({ score }) {
+  if (score <= 0) return null;
+  return (
+    <div className="text-yellow-300">High Score: <span className="font-bold">{score}₵</span></div>
+  );
+}
+
+export default HighScoreDisplay;

--- a/src/components/PopupFrenzy.jsx
+++ b/src/components/PopupFrenzy.jsx
@@ -1,11 +1,13 @@
 import { useState, useEffect } from 'react';
 import { getItem, setItem } from '../lib/storage';
+import HighScoreDisplay from './HighScoreDisplay';
 
 function PopupFrenzy() {
   const [running, setRunning] = useState(false);
   const [popups, setPopups] = useState([]);
   const [timeLeft, setTimeLeft] = useState(20);
   const [earned, setEarned] = useState(0);
+  const [highScore, setHighScore] = useState(() => getItem('popupHighScore') ?? 0);
 
   useEffect(() => {
     let timerId;
@@ -16,10 +18,14 @@ function PopupFrenzy() {
         setRunning(false);
         const balance = getItem('balance') ?? 0;
         setItem('balance', balance + earned);
+        if (earned > highScore) {
+          setHighScore(earned);
+          setItem('popupHighScore', earned);
+        }
       }
     }
     return () => clearTimeout(timerId);
-  }, [running, timeLeft, earned]);
+  }, [running, timeLeft, earned, highScore]);
 
   useEffect(() => {
     let spawnId;
@@ -62,6 +68,7 @@ function PopupFrenzy() {
           {earned > 0 && (
             <div className="text-green-300">You earned {earned}₵!</div>
           )}
+          <HighScoreDisplay score={highScore} />
         </div>
       )}
       {running && (


### PR DESCRIPTION
## Summary
- keep track of personal high score for the Popup Frenzy minigame
- show the saved high score with a new component
- document the feature in the readme

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686dd1b4dc288329b158bf3c96a41eda