### PR TITLE
Add stock types and spike events

### DIFF
--- a/src/components/StockCard.jsx
+++ b/src/components/StockCard.jsx
@@ -15,6 +15,17 @@ function StockCard({ stock, owned, balance, onBuy, onSell }) {
         <div className="flex items-center gap-2">
           <span className="text-3xl">{stock.emoji}</span>
           <div className="text-green-300 text-xl font-bold">{stock.name}</div>
+          <span
+            className={`text-xs px-2 rounded ${
+              stock.type === 'stable'
+                ? 'bg-gray-700 text-gray-300'
+                : stock.type === 'risky'
+                ? 'bg-red-700 text-red-200'
+                : 'bg-blue-700 text-blue-200'
+            }`}
+          >
+            {stock.type}
+          </span>
         </div>
         <div className="text-yellow-300">Owned: {owned}</div>
       </div>
@@ -28,6 +39,15 @@ function StockCard({ stock, owned, balance, onBuy, onSell }) {
           >
             {stock.price > stock.prevPrice ? '▲' : '▼'}
             {Math.abs(stock.price - stock.prevPrice)}₵
+          </span>
+        )}
+        {stock.event && (
+          <span
+            className={`ml-2 ${
+              stock.event === 'spike-up' ? 'text-green-400' : 'text-red-400'
+            } animate-flash`}
+          >
+            ⚡
           </span>
         )}
       </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { updateStockPrices } from '../utils/stockSimulator';
 import PortfolioChart from '../components/PortfolioChart';
 import BalanceDisplay from '../components/BalanceDisplay';
 import PortfolioValueDisplay from '../components/PortfolioValueDisplay';
@@ -19,12 +20,12 @@ import confetti from "canvas-confetti";
 import { getItem, setItem, removeItem } from "../lib/storage";
 
 const INITIAL_STOCKS = [
-  { name: 'BananaCorp', emoji: '🍌', price: 120, prevPrice: 120 },
-  { name: 'DuckWare', emoji: '🦆', price: 80, prevPrice: 80 },
-  { name: 'ToasterInc', emoji: '🔥', price: 200, prevPrice: 200 },
-  { name: 'SpaceY', emoji: '🚀', price: 250, prevPrice: 250 },
-  { name: 'LlamaSoft', emoji: '🦙', price: 150, prevPrice: 150 },
-  { name: 'Robotix', emoji: '🤖', price: 180, prevPrice: 180 },
+  { name: 'BananaCorp', emoji: '🍌', price: 120, prevPrice: 120, type: 'stable' },
+  { name: 'DuckWare', emoji: '🦆', price: 80, prevPrice: 80, type: 'risky' },
+  { name: 'ToasterInc', emoji: '🔥', price: 200, prevPrice: 200, type: 'trending' },
+  { name: 'SpaceY', emoji: '🚀', price: 250, prevPrice: 250, type: 'risky' },
+  { name: 'LlamaSoft', emoji: '🦙', price: 150, prevPrice: 150, type: 'stable' },
+  { name: 'Robotix', emoji: '🤖', price: 180, prevPrice: 180, type: 'trending' },
 ];
 
 function Dashboard() {
@@ -73,18 +74,12 @@ function Dashboard() {
     }, 3000);
   };
 
-  const updateStockPrices = () => {
-    setStocks((prev) =>
-      prev.map((stock) => {
-        const changePct = (Math.random() - 0.5) * 0.2; // -10% to +10%
-        const newPrice = Math.max(1, Math.round(stock.price * (1 + changePct)));
-        return { ...stock, prevPrice: stock.price, price: newPrice };
-      })
-    );
+  const updateStockPricesWrapper = () => {
+    setStocks((prev) => updateStockPrices(prev));
   };
 
   useEffect(() => {
-    const id = setInterval(updateStockPrices, 5000);
+    const id = setInterval(updateStockPricesWrapper, 5000);
     return () => clearInterval(id);
   }, []);
 

--- a/src/utils/stockSimulator.js
+++ b/src/utils/stockSimulator.js
@@ -1,0 +1,32 @@
+export function updateStockPrices(stocks) {
+  return stocks.map((stock) => {
+    let volatility = 0.1; // default
+    let bias = 0;
+    switch (stock.type) {
+      case 'stable':
+        volatility = 0.05; // +/-2.5%
+        break;
+      case 'risky':
+        volatility = 0.4; // +/-20%
+        break;
+      case 'trending':
+        volatility = 0.15; // +/-7.5%
+        bias = 0.03; // upward bias
+        break;
+      default:
+        break;
+    }
+    const changePct = bias + (Math.random() - 0.5) * volatility;
+    let newPrice = Math.max(1, Math.round(stock.price * (1 + changePct)));
+
+    let event = null;
+    if (Math.random() < 0.05) { // 5% chance of spike
+      const spikeUp = Math.random() < 0.5;
+      const spikePct = spikeUp ? 0.5 : -0.5; // +/-50%
+      newPrice = Math.max(1, Math.round(newPrice * (1 + spikePct)));
+      event = spikeUp ? 'spike-up' : 'spike-down';
+    }
+
+    return { ...stock, prevPrice: stock.price, price: newPrice, event };
+  });
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,9 +17,14 @@ export default {
             animationTimingFunction: 'cubic-bezier(0,0,0.2,1)',
           },
         },
+        flash: {
+          '0%, 100%': { opacity: '1' },
+          '50%': { opacity: '0.2' },
+        },
       },
       animation: {
         'bounce-small': 'bounce-small 0.5s',
+        flash: 'flash 0.5s ease-in-out',
       },
     },
   },


### PR DESCRIPTION
## Summary
- add stock type categories and random spike events
- use new stock simulator utility to update prices
- show stock type badges and spike icons on stock cards
- add flash animation for spikes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e4b2315088329ba123fa7854a8459