### PR TITLE
Fix minigame page by defining callbacks before use

### DIFF
--- a/src/components/CoinGrabber.jsx
+++ b/src/components/CoinGrabber.jsx
@@ -7,6 +7,16 @@ function CoinGrabber() {
   const [timeLeft, setTimeLeft] = useState(20);
   const [earned, setEarned] = useState(0);
 
+  const spawnCoin = useCallback(() => {
+    const id = Date.now() + Math.random();
+    const x = Math.random() * 90;
+    const y = Math.random() * 80 + 5;
+    setCoins((c) => [...c, { id, x, y }]);
+    setTimeout(() => {
+      setCoins((c) => c.filter((coin) => coin.id !== id));
+    }, 1500);
+  }, []);
+
   const stopGame = useCallback(() => {
     setRunning(false);
     const balance = getItem('balance') ?? 0;
@@ -32,16 +42,6 @@ function CoinGrabber() {
     }
     return () => clearInterval(spawnId);
   }, [running, spawnCoin]);
-
-  const spawnCoin = useCallback(() => {
-    const id = Date.now() + Math.random();
-    const x = Math.random() * 90;
-    const y = Math.random() * 80 + 5;
-    setCoins((c) => [...c, { id, x, y }]);
-    setTimeout(() => {
-      setCoins((c) => c.filter((coin) => coin.id !== id));
-    }, 1500);
-  }, []);
 
   const collectCoin = (id) => {
     setCoins((c) => c.filter((coin) => coin.id !== id));

--- a/src/components/PopupFrenzy.jsx
+++ b/src/components/PopupFrenzy.jsx
@@ -19,7 +19,7 @@ function PopupFrenzy() {
     ],
     []
   );
-  const styles = useMemo(
+const styles = useMemo(
     () => [
       { bg: 'bg-pink-600', border: 'border-pink-500', text: 'text-pink-200' },
       { bg: 'bg-yellow-600', border: 'border-yellow-400', text: 'text-yellow-200' },
@@ -27,6 +27,17 @@ function PopupFrenzy() {
     ],
     []
   );
+
+  const spawnPopup = useCallback(() => {
+    const id = Date.now() + Math.random();
+    const x = Math.random() * 80;
+    const y = Math.random() * 60 + 10;
+    const style = styles[Math.floor(Math.random() * styles.length)];
+    const message = messages[Math.floor(Math.random() * messages.length)];
+    setPopups((p) => [...p, { id, x, y, style, message }]);
+  }, [messages, styles]);
+
+
 
   const stopGame = useCallback(() => {
     setRunning(false);
@@ -57,16 +68,6 @@ function PopupFrenzy() {
     }
     return () => clearInterval(spawnId);
   }, [running, spawnPopup]);
-
-  const spawnPopup = useCallback(() => {
-    const id = Date.now() + Math.random();
-    const x = Math.random() * 80;
-    const y = Math.random() * 60 + 10;
-    const style = styles[Math.floor(Math.random() * styles.length)];
-    const message = messages[Math.floor(Math.random() * messages.length)];
-    setPopups((p) => [...p, { id, x, y, style, message }]);
-  }, [messages, styles]);
-
   const closePopup = (id) => {
     setPopups((p) => p.filter((pop) => pop.id !== id));
     setEarned((e) => e + 10);


### PR DESCRIPTION
## Summary
- define `spawnPopup` before `useEffect` in `PopupFrenzy`
- define `spawnCoin` before `useEffect` in `CoinGrabber`

The minigame page crashed because these callbacks were referenced before they were defined. Moving them earlier prevents the runtime `ReferenceError`.

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e51ff95508329b32079edccdbf3d8