### PR TITLE
Add stock scarcity limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Your best score is now saved locally and shown below the start button.
 The Market window now includes a search bar to quickly filter stocks by name.
 When text is entered, a **Clear** button appears to reset the filter in one click.
 
+## Stock Scarcity
+
+Each stock now has a global supply and optional per-player cap. Remaining shares
+are shown on every stock card and purchases are blocked when limits are reached.
+
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.

--- a/src/components/StockCard.jsx
+++ b/src/components/StockCard.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-function StockCard({ stock, owned, balance, onBuy, onSell }) {
+function StockCard({ stock, owned, balance, remaining, limit, onBuy, onSell }) {
   const [bouncing, setBouncing] = useState(false);
 
   const handleBuy = () => {
@@ -51,11 +51,18 @@ function StockCard({ stock, owned, balance, onBuy, onSell }) {
           </span>
         )}
       </div>
+      <div className="text-green-400 text-xs">Remaining: {remaining}</div>
+      {limit !== undefined && (
+        <div className="text-yellow-300 text-xs">Limit: {limit}</div>
+      )}
+      {limit !== undefined && owned >= limit && (
+        <div className="text-red-400 text-xs">Cap reached</div>
+      )}
       <div className="flex gap-2">
         <button
           onClick={handleBuy}
           className={`bg-green-700 hover:bg-green-900 text-white px-3 py-1 rounded disabled:opacity-50 ${bouncing ? 'animate-bounce-small' : ''}`}
-          disabled={balance < stock.price}
+          disabled={balance < stock.price || remaining <= 0 || (limit !== undefined && owned >= limit)}
         >
           Buy
         </button>

--- a/src/components/StockList.jsx
+++ b/src/components/StockList.jsx
@@ -1,6 +1,6 @@
 import StockCard from './StockCard';
 
-function StockList({ stocks, portfolio, balance, onBuy, onSell }) {
+function StockList({ stocks, portfolio, balance, supply, limits, onBuy, onSell }) {
   return (
     <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
       {stocks.map((stock) => (
@@ -9,6 +9,8 @@ function StockList({ stocks, portfolio, balance, onBuy, onSell }) {
           stock={stock}
           owned={portfolio[stock.name] || 0}
           balance={balance}
+          remaining={supply[stock.name] || 0}
+          limit={limits[stock.name]?.perPlayerLimit}
           onBuy={onBuy}
           onSell={onSell}
         />

--- a/src/data/stockLimits.json
+++ b/src/data/stockLimits.json
@@ -1,0 +1,8 @@
+{
+  "BananaCorp": { "globalLimit": 100, "perPlayerLimit": 25 },
+  "DuckWare": { "globalLimit": 80 },
+  "ToasterInc": { "globalLimit": 60, "perPlayerLimit": 10 },
+  "SpaceY": { "globalLimit": 50 },
+  "LlamaSoft": { "globalLimit": 70, "perPlayerLimit": 15 },
+  "Robotix": { "globalLimit": 40 }
+}


### PR DESCRIPTION
## Summary
- add stock scarcity JSON data
- load limits in dashboard and track global supply
- block buys that exceed global or per-player caps
- update stock card UI to show remaining shares and limits
- document new feature in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e575097f0832985cfa6e3369f633f