### PR TITLE
Fix button sizes and add closable buy toasts

### DIFF
--- a/src/components/StockCard.jsx
+++ b/src/components/StockCard.jsx
@@ -56,14 +56,14 @@ function StockCard({ stock, owned, balance, onBuy, onSell }) {
       <div className="flex gap-2">
         <button
           onClick={handleBuy}
-          className={`bg-green-700 hover:bg-green-900 text-white px-3 py-1 rounded disabled:opacity-50 ${bouncing ? 'animate-bounce-small' : ''}`}
+          className={`bg-green-700 hover:bg-green-900 text-white text-sm px-2 py-1 rounded disabled:opacity-50 ${bouncing ? 'animate-bounce-small' : ''}`}
           disabled={balance < stock.price}
         >
           Buy
         </button>
         <button
           onClick={() => onSell(stock.name)}
-          className="bg-red-700 hover:bg-red-900 text-white px-3 py-1 rounded disabled:opacity-50"
+          className="bg-red-700 hover:bg-red-900 text-white text-sm px-2 py-1 rounded disabled:opacity-50"
           disabled={owned === 0}
         >
           Sell

--- a/src/components/ToastContainer.jsx
+++ b/src/components/ToastContainer.jsx
@@ -1,12 +1,20 @@
-function ToastContainer({ toasts }) {
+function ToastContainer({ toasts, onClose }) {
   return (
     <div className="fixed top-4 right-4 flex flex-col gap-2 z-50">
       {toasts.map((toast) => (
         <div
           key={toast.id}
-          className="bg-gray-800 border border-green-400 text-green-300 px-4 py-2 rounded shadow"
+          className="bg-gray-800 border border-green-400 text-green-300 px-4 py-2 rounded shadow relative"
         >
           {toast.text}
+          {toast.closable && (
+            <button
+              onClick={() => onClose(toast.id)}
+              className="absolute top-1 right-1 text-green-300 hover:text-white"
+            >
+              ×
+            </button>
+          )}
         </div>
       ))}
     </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -66,12 +66,16 @@ function Dashboard() {
 
   const [toasts, setToasts] = useState([]);
 
-  const addToast = (text) => {
+  const addToast = (text, closable = false) => {
     const id = Date.now();
-    setToasts((t) => [...t, { id, text }]);
+    setToasts((t) => [...t, { id, text, closable }]);
     setTimeout(() => {
       setToasts((t) => t.filter((toast) => toast.id !== id));
     }, 3000);
+  };
+
+  const closeToast = (id) => {
+    setToasts((t) => t.filter((toast) => toast.id !== id));
   };
 
   const updateStockPricesWrapper = () => {
@@ -170,7 +174,7 @@ function Dashboard() {
     if (balance >= stock.price) {
       setBalance((b) => b - stock.price);
       setPortfolio((p) => ({ ...p, [stockName]: (p[stockName] || 0) + 1 }));
-      addToast(`Bought 1 ${stockName} for ${stock.price}\u00A2`);
+      addToast(`Bought 1 ${stockName} for ${stock.price}\u00A2`, true);
       confetti({ particleCount: 80, spread: 70, origin: { y: 0.6 } });
     } else {
       addToast(`Not enough balance to buy ${stockName}`);
@@ -279,7 +283,7 @@ function Dashboard() {
           />
         </WindowFrame>
         <Footer onReset={resetGame} />
-        <ToastContainer toasts={toasts} />
+        <ToastContainer toasts={toasts} onClose={closeToast} />
       </div>
     </Layout>
   );


### PR DESCRIPTION
## Summary
- tweak Buy/Sell button styling so they fit within stock cards
- add optional close button to toast notifications
- show close button on purchase messages

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e9193c8ac8329b5fa6d38bd2c4711