### PR TITLE
Improve minigames UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=Press+Start+2P&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -6,7 +6,7 @@ function TopNav() {
 
   return (
     <nav className="sticky top-0 z-10 flex justify-between items-center px-6 py-4 bg-gradient-to-b from-gray-900/80 to-black/80 backdrop-blur-md text-green-400 border-b border-green-600 shadow-lg">
-      <NavLink to="/" className="text-pink-400 glitch text-xl font-bold tracking-widest">
+      <NavLink to="/" className="text-pink-400 glitch text-xl font-bold tracking-widest font-pixel">
         404CACHE
       </NavLink>
       <div className="flex flex-col sm:flex-row sm:space-x-4 space-y-2 sm:space-y-0">

--- a/src/index.css
+++ b/src/index.css
@@ -189,14 +189,22 @@ body,
 /* Neon card and button styles */
 .neon-card {
   border: 2px solid #0ff;
-  box-shadow: 0 0 8px #0ff;
+  box-shadow: 0 0 12px #0ff;
   background-color: rgba(0,0,0,0.6);
   border-radius: 0.5rem;
 }
 .neon-button {
-  @apply bg-green-700 text-white px-4 py-2 rounded border border-cyan-400 shadow-[0_0_6px_#0ff] transition;
+  @apply bg-green-700 text-white px-4 py-2 rounded border border-cyan-400 shadow-[0_0_8px_#0ff] transition font-pixel;
 }
 .neon-button:hover {
   @apply shadow-[0_0_12px_#0ff] animate-pulse;
+}
+
+.font-pixel {
+  font-family: 'Press Start 2P', monospace;
+}
+
+body {
+  cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Cpath stroke='cyan' d='M8 0v16M0 8h16'/%3E%3C/svg%3E") 8 8, crosshair;
 }
 

--- a/src/pages/Minigames.jsx
+++ b/src/pages/Minigames.jsx
@@ -5,17 +5,17 @@ import CoinGrabber from '../components/CoinGrabber';
 function Minigames() {
   return (
     <Layout>
-      <section className="mt-10 text-green-300 space-y-8">
-        <h2 className="text-center text-3xl text-green-400 mb-6">Minigames</h2>
-        <div className="grid gap-8 md:grid-cols-2">
-          <article className="neon-card flex flex-col items-center">
-            <h3 className="text-2xl mb-2 text-green-200">Pop-up Frenzy</h3>
-            <p className="mb-4 text-sm text-green-400">Close pop-ups fast to earn more coins.</p>
+      <section className="mt-10 text-green-300 space-y-12 flex flex-col items-center">
+        <h2 className="text-center text-4xl font-pixel text-green-400 mb-8">Minigames</h2>
+        <div className="grid gap-12 md:grid-cols-2 w-full place-items-center">
+          <article className="neon-card flex flex-col items-center p-4 space-y-2">
+            <h3 className="text-2xl font-pixel text-green-200">Pop-up Frenzy</h3>
+            <p className="mb-2 text-sm font-mono text-green-400">Close pop-ups fast to earn more coins.</p>
             <PopupFrenzy />
           </article>
-          <article className="neon-card flex flex-col items-center">
-            <h3 className="text-2xl mb-2 text-green-200">Coin Grabber</h3>
-            <p className="mb-4 text-sm text-green-400">Click coins before they vanish.</p>
+          <article className="neon-card flex flex-col items-center p-4 space-y-2">
+            <h3 className="text-2xl font-pixel text-green-200">Coin Grabber</h3>
+            <p className="mb-2 text-sm font-mono text-green-400">Click coins before they vanish.</p>
             <CoinGrabber />
           </article>
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,7 @@ export default {
     extend: {
       fontFamily: {
         mono: ['"Share Tech Mono"', 'monospace'],
+        pixel: ['"Press Start 2P"', 'monospace'],
       },
       keyframes: {
         'bounce-small': {


### PR DESCRIPTION
## Summary
- add pixel-style font link
- highlight site logo and minigame titles with `font-pixel`
- update neon card/button styling and add custom cursor
- center minigame layout and tweak spacing
- **remove binary cursor image in favor of CSS data URI**

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e58910c1883299ca3c61f23b1d659