### PR TITLE
Add theme toggle

### DIFF
--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+import { getItem, setItem } from '../lib/storage';
+
+function ThemeToggle() {
+  const [theme, setTheme] = useState(() => getItem('theme') || 'default');
+
+  useEffect(() => {
+    if (theme === 'retro') {
+      document.documentElement.style.setProperty(
+        '--text-color',
+        '#0f0'
+      );
+      document.documentElement.style.setProperty(
+        '--bg-color',
+        'radial-gradient(circle at 50% 0px, rgb(0, 34, 0), rgb(0, 0, 0))'
+      );
+    } else {
+      document.documentElement.style.setProperty(
+        '--text-color',
+        '#0ff'
+      );
+      document.documentElement.style.setProperty(
+        '--bg-color',
+        'radial-gradient(circle at 50% 0px, rgb(0, 34, 34), rgb(0, 0, 0))'
+      );
+    }
+    setItem('theme', theme);
+  }, [theme]);
+
+  return (
+    <button
+      onClick={() => setTheme(theme === 'default' ? 'retro' : 'default')}
+      className="px-3 py-1 hover:text-cyan-400 hover:scale-105 transition-all uppercase font-semibold"
+    >
+      {theme === 'default' ? 'Retro Mode' : 'Default Mode'}
+    </button>
+  );
+}
+
+export default ThemeToggle;

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -1,4 +1,5 @@
 import { NavLink } from 'react-router-dom';
+import ThemeToggle from './ThemeToggle';
 
 function TopNav() {
   const baseClasses =
@@ -9,7 +10,7 @@ function TopNav() {
       <NavLink to="/" className="text-pink-400 glitch text-xl font-bold tracking-widest">
         404CACHE
       </NavLink>
-      <div className="flex flex-col sm:flex-row sm:space-x-4 space-y-2 sm:space-y-0">
+      <div className="flex flex-col sm:flex-row sm:space-x-4 space-y-2 sm:space-y-0 items-center">
         <NavLink
           to="/"
           className={({ isActive }) => `${baseClasses} ${isActive ? 'text-cyan-400' : ''}`}
@@ -34,6 +35,7 @@ function TopNav() {
         >
           Profile
         </NavLink>
+        <ThemeToggle />
       </div>
     </nav>
   );

--- a/src/pages/os/Fragments.jsx
+++ b/src/pages/os/Fragments.jsx
@@ -3,7 +3,7 @@ import WindowFrame from '../../components/WindowFrame'
 import { getItem, setItem } from '../../lib/storage'
 
 function Fragments() {
-  const [fragments, setFragments] = useState(() => getItem('memoryFragments') || {})
+  const [fragments, _setFragments] = useState(() => getItem('memoryFragments') || {})
 
   useEffect(() => {
     setItem('memoryFragments', fragments)


### PR DESCRIPTION
## Summary
- add ThemeToggle component for retro mode
- hook ThemeToggle into TopNav
- fix unused variable in Fragments page

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686ed3ee6dc08329a2d8e1e0becec1db