### PR TITLE
Improve stock card layout and terminal theme

### DIFF
--- a/src/components/StockCard.jsx
+++ b/src/components/StockCard.jsx
@@ -39,19 +39,22 @@ function StockCard({ stock, owned, balance, onBuy, onSell, globalRemaining, play
   return (
     <div
       onClick={() => setExpanded((e) => !e)}
-      className={`bg-gradient-to-br from-gray-900 to-gray-800 border p-4 mb-4 rounded shadow-lg shadow-green-700/30 transition-all hover:scale-105 flex flex-col gap-2 font-mono cursor-pointer ${
+      className={`neon-card p-4 mb-4 flex flex-col gap-2 cursor-pointer transition-all hover:shadow-cyan-500 hover:scale-105 min-h-56 ${
         flash === 'buy'
           ? 'border-green-500 animate-flash'
           : flash === 'sell'
           ? 'border-red-500 animate-flash'
-          : 'border-green-500'
-      } ${expanded ? 'max-h-80' : 'max-h-48'}`}
+          : 'border-cyan-400'
+      } ${expanded ? 'max-h-80' : 'max-h-56'}`}
     >
-      <div className="flex justify-between items-center flex-wrap gap-y-1">
+      <div className="flex justify-between items-start flex-wrap gap-y-1">
         <div className="flex items-center gap-2 flex-wrap">
           <span className="text-3xl">{stock.emoji}</span>
-          <div className="text-green-300 text-xl font-bold break-words">
-            {stock.name}
+          <div>
+            <div className="text-green-300 text-xl font-bold leading-none">
+              {stock.name}
+            </div>
+            <div className="text-xs font-mono text-green-500">{stock.ticker}</div>
           </div>
           <span
             className={`text-xs px-2 rounded ${
@@ -67,16 +70,18 @@ function StockCard({ stock, owned, balance, onBuy, onSell, globalRemaining, play
         </div>
         <div className="text-yellow-300 text-sm">Owned: {owned}</div>
       </div>
-      <div className="text-blue-300 flex items-center">
-        Price: {stock.price}₵
+      <div className="text-blue-300 flex items-baseline gap-1 tabular-nums whitespace-nowrap">
+        <span>Price:</span>
+        <span>{stock.price}¢</span>
         {stock.price !== stock.prevPrice && (
           <span
             className={`ml-2 text-sm ${
               stock.price > stock.prevPrice ? 'text-green-400' : 'text-red-400'
             }`}
+            style={{ minWidth: '3.5rem' }}
           >
             {stock.price > stock.prevPrice ? '▲' : '▼'}
-            {Math.abs(stock.price - stock.prevPrice)}₵
+            {Math.abs(stock.price - stock.prevPrice)}¢
           </span>
         )}
         {stock.event && (
@@ -105,17 +110,17 @@ function StockCard({ stock, owned, balance, onBuy, onSell, globalRemaining, play
           <span className="text-red-400 ml-1">Cap reached</span>
         )}
       </div>
-      <div className="flex gap-2">
+      <div className="mt-auto flex gap-2">
         <button
           onClick={handleBuy}
-          className="bg-green-700 hover:bg-green-900 text-white px-2 py-1 text-sm rounded disabled:opacity-50 transition-transform duration-200 ease-out hover:scale-105"
+          className="neon-button bg-green-700 hover:bg-green-900 disabled:opacity-50"
           disabled={balance < stock.price}
         >
           Buy
         </button>
         <button
           onClick={handleSell}
-          className="bg-red-700 hover:bg-red-900 text-white px-2 py-1 text-sm rounded disabled:opacity-50 transition-transform duration-200 ease-out hover:scale-105"
+          className="neon-button bg-red-700 hover:bg-red-900 disabled:opacity-50"
           disabled={owned === 0}
         >
           Sell

--- a/src/components/StockList.jsx
+++ b/src/components/StockList.jsx
@@ -12,14 +12,16 @@ function StockList({ stocks, portfolio, balance, onBuy, onSell, limits, globalOw
     groups[cat].push(s);
   });
 
-  const containerCls = `grid gap-4 ${terminalMode ? 'bg-black text-green-300 font-mono p-2' : ''}`;
+  const containerCls = `grid gap-6 ${terminalMode ? 'p-2' : ''}`;
 
   return (
     <div className={containerCls}>
       {Object.entries(groups).map(([cat, list]) => (
-        <div key={cat} className="mb-6">
-          <h3 className="mb-2 text-lg font-bold text-green-400">{cat}</h3>
-          <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+        <div key={cat} className="mb-8">
+          <h3 className="sticky top-0 z-10 bg-gray-900/80 backdrop-blur px-2 py-1 border-b border-green-500 text-lg font-bold text-green-400">
+            {cat}
+          </h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-2">
             {list.map((stock) => {
               const limit = limits?.[stock.name];
               const remaining = limit ? limit.globalLimit - (globalOwned[stock.name] || 0) : Infinity;

--- a/src/components/TerminalModeToggle.jsx
+++ b/src/components/TerminalModeToggle.jsx
@@ -7,6 +7,7 @@ function TerminalModeToggle({ onToggle }) {
   useEffect(() => {
     setItem('terminalMode', enabled);
     onToggle(enabled);
+    document.documentElement.classList.toggle('terminal-mode', enabled);
   }, [enabled, onToggle]);
 
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -102,6 +102,12 @@ button:focus-visible {
   --font-family: 'Share Tech Mono', monospace;
 }
 
+.terminal-mode {
+  --bg-color: radial-gradient(circle at 50% 0px, rgb(0, 34, 0), rgb(0, 0, 0));
+  --text-color: #0f0;
+  --font-family: 'Share Tech Mono', monospace;
+}
+
 html,
 body,
 #root {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -25,18 +25,18 @@ import confetti from "canvas-confetti";
 import { getItem, setItem, removeItem } from "../lib/storage";
 
 const INITIAL_STOCKS = [
-  { name: 'BananaCorp', emoji: '🍌', price: 120, prevPrice: 120, type: 'stable', history: [120] },
-  { name: 'DuckWare', emoji: '🦆', price: 80, prevPrice: 80, type: 'risky', history: [80] },
-  { name: 'ToasterInc', emoji: '🔥', price: 200, prevPrice: 200, type: 'trending', history: [200] },
-  { name: 'SpaceY', emoji: '🚀', price: 250, prevPrice: 250, type: 'risky', history: [250] },
-  { name: 'LlamaSoft', emoji: '🦙', price: 150, prevPrice: 150, type: 'stable', history: [150] },
-  { name: 'Robotix', emoji: '🤖', price: 180, prevPrice: 180, type: 'trending', history: [180] },
+  { name: 'BananaCorp', ticker: 'BAN', emoji: '🍌', price: 120, prevPrice: 120, type: 'stable', history: [120] },
+  { name: 'DuckWare', ticker: 'DUCK', emoji: '🦆', price: 80, prevPrice: 80, type: 'risky', history: [80] },
+  { name: 'ToasterInc', ticker: 'TOAST', emoji: '🔥', price: 200, prevPrice: 200, type: 'trending', history: [200] },
+  { name: 'SpaceY', ticker: 'SPACE', emoji: '🚀', price: 250, prevPrice: 250, type: 'risky', history: [250] },
+  { name: 'LlamaSoft', ticker: 'LLMA', emoji: '🦙', price: 150, prevPrice: 150, type: 'stable', history: [150] },
+  { name: 'Robotix', ticker: 'BOT', emoji: '🤖', price: 180, prevPrice: 180, type: 'trending', history: [180] },
 ];
 
 const RARE_MARKETS = {
   cyber: [
-    { name: 'CyberDyne', emoji: '💻', price: 300, prevPrice: 300, type: 'rare', history: [300] },
-    { name: 'MystiCorp', emoji: '🧪', price: 400, prevPrice: 400, type: 'rare', history: [400] },
+    { name: 'CyberDyne', ticker: 'CYBR', emoji: '💻', price: 300, prevPrice: 300, type: 'rare', history: [300] },
+    { name: 'MystiCorp', ticker: 'MYST', emoji: '🧪', price: 400, prevPrice: 400, type: 'rare', history: [400] },
   ],
 };
 


### PR DESCRIPTION
## Summary
- add stock ticker symbols
- make Terminal Mode toggle update root styles
- support global terminal-mode variables in CSS
- standardize StockCard layout and price row
- display stocks in responsive grid with sticky category headers

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ef49187a88329a6f66dc3afb4b42c