### PR TITLE
Add profile customization and stats

### DIFF
--- a/src/components/ProfileSettings.jsx
+++ b/src/components/ProfileSettings.jsx
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react';
+import { getItem, setItem } from '../lib/storage';
+
+const AVATARS = ['😎', '👾', '🤖', '🦙', '🐱', '🦆'];
+
+function ProfileSettings() {
+  const [name, setName] = useState('');
+  const [avatar, setAvatar] = useState(AVATARS[0]);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    const storedName = getItem('profileName');
+    const storedAvatar = getItem('profileAvatar');
+    if (storedName) setName(storedName);
+    if (storedAvatar) setAvatar(storedAvatar);
+  }, []);
+
+  const save = () => {
+    setItem('profileName', name.trim() || 'User');
+    setItem('profileAvatar', avatar);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  return (
+    <div className="mt-6 space-y-3 text-green-300">
+      <h3 className="text-xl text-green-400">Profile Settings</h3>
+      <div>
+        <label className="block text-sm mb-1">Name</label>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full px-2 py-1 bg-gray-900 border border-green-600"
+        />
+      </div>
+      <div>
+        <label className="block text-sm mb-1">Avatar</label>
+        <div className="flex space-x-2">
+          {AVATARS.map((a) => (
+            <button
+              key={a}
+              onClick={() => setAvatar(a)}
+              className={`text-2xl px-2 py-1 border-2 rounded ${
+                avatar === a ? 'border-green-400' : 'border-transparent'
+              }`}
+            >
+              {a}
+            </button>
+          ))}
+        </div>
+      </div>
+      <button onClick={save} className="neon-button">
+        Save
+      </button>
+      {saved && <div className="text-green-400">Saved!</div>}
+    </div>
+  );
+}
+
+export default ProfileSettings;

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -1,10 +1,13 @@
 import { NavLink } from 'react-router-dom';
 import ThemeToggle from './ThemeToggle';
 import SoundToggle from './SoundToggle';
+import { getItem } from '../lib/storage';
 
 function TopNav() {
   const baseClasses =
     'px-3 py-1 hover:text-cyan-400 hover:scale-105 transition-all uppercase font-semibold';
+  const name = getItem('profileName') || 'User';
+  const avatar = getItem('profileAvatar') || '😎';
 
   return (
     <nav className="sticky top-0 z-10 flex justify-between items-center px-6 py-4 bg-gradient-to-b from-gray-900/80 to-black/80 backdrop-blur-md text-green-400 border-b border-green-600 shadow-lg">
@@ -38,6 +41,10 @@ function TopNav() {
         </NavLink>
         <SoundToggle />
         <ThemeToggle />
+        <div className="hidden sm:flex items-center ml-2 space-x-1">
+          <span className="text-xl">{avatar}</span>
+          <span className="text-sm">{name}</span>
+        </div>
       </div>
     </nav>
   );

--- a/src/games/Minigames/PopupFrenzy.jsx
+++ b/src/games/Minigames/PopupFrenzy.jsx
@@ -1,10 +1,12 @@
 import { useState, useEffect } from 'react';
+import { getItem, setItem } from '../../lib/storage';
 
 function PopupFrenzy() {
   const [running, setRunning] = useState(false);
   const [popups, setPopups] = useState([]);
   const [timeLeft, setTimeLeft] = useState(20);
   const [score, setScore] = useState(0);
+  const [highScore, setHighScore] = useState(() => getItem('popupHighScore') || 0);
 
   useEffect(() => {
     if (!running) return;
@@ -29,6 +31,18 @@ function PopupFrenzy() {
     return () => clearInterval(id);
   }, [running]);
 
+  useEffect(() => {
+    if (!running && score > 0) {
+      setHighScore((hs) => {
+        if (score > hs) {
+          setItem('popupHighScore', score);
+          return score;
+        }
+        return hs;
+      });
+    }
+  }, [running, score]);
+
   const closePopup = (id) => {
     setPopups((p) => p.filter((pop) => pop.id !== id));
     setScore((s) => s + 1);
@@ -47,6 +61,7 @@ function PopupFrenzy() {
         <div className="flex flex-col items-center justify-center h-full space-y-2">
           <button onClick={startGame} className="neon-button">Start Pop-up Frenzy</button>
           {score > 0 && <div>Score: {score}</div>}
+          {highScore > 0 && <div className="text-yellow-300">Best: {highScore}</div>}
         </div>
       ) : (
         <>

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,12 +1,25 @@
 import Layout from '../components/Layout';
 import ProfileStats from '../components/ProfileStats';
+import ProfileSettings from '../components/ProfileSettings';
+import PortfolioChart from '../components/PortfolioChart';
+import HighScoreDisplay from '../components/HighScoreDisplay';
+import { getItem } from '../lib/storage';
 
 function Profile() {
+  const history = getItem('netWorthHistory') ?? [];
+  const highScore = getItem('popupHighScore') ?? 0;
+  const name = getItem('profileName') ?? 'User';
+  const avatar = getItem('profileAvatar') ?? '😎';
+
   return (
     <Layout>
-      <div className="text-center text-green-400 mt-10">
-        <h2 className="text-3xl mb-4">Profile</h2>
+      <div className="text-center text-green-400 mt-10 space-y-6">
+        <div className="text-5xl">{avatar}</div>
+        <h2 className="text-3xl mb-2">{name}'s Profile</h2>
         <ProfileStats />
+        <HighScoreDisplay score={highScore} />
+        <PortfolioChart data={history} />
+        <ProfileSettings />
       </div>
     </Layout>
   );


### PR DESCRIPTION
## Summary
- add profile settings component for name and avatar
- extend profile page with chart, high score and settings
- display current profile in the navigation bar
- store Pop‑up Frenzy high score in local storage

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686effdc82a08329aa3a07ebc261574c