### PR TITLE
Fix stock card expansion on buy/sell

### DIFF
--- a/src/components/StockCard.jsx
+++ b/src/components/StockCard.jsx
@@ -13,13 +13,15 @@ function StockCard({ stock, owned, balance, onBuy, onSell, globalRemaining, play
   const [expanded, setExpanded] = useState(false);
   const [flash, setFlash] = useState(null);
 
-  const handleBuy = () => {
+  const handleBuy = (e) => {
+    e.stopPropagation();
     setFlash('buy');
     onBuy(stock.name);
     setTimeout(() => setFlash(null), 300);
   };
 
-  const handleSell = () => {
+  const handleSell = (e) => {
+    e.stopPropagation();
     setFlash('sell');
     onSell(stock.name);
     setTimeout(() => setFlash(null), 300);


### PR DESCRIPTION
## Summary
- stop card click handler from firing when clicking Buy/Sell buttons

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686f035dc42c8329a8a3e81c85fdf603