### PR TITLE
Add scalable limit upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 404Cache Stock Market Demo
 
-This project uses Vite and React to showcase the early MVP for the 404Cache stock market game. Prices update automatically and you can buy or sell a collection of **six** playful stocks to watch your balance change. Each stock sports its own emoji for quick recognition. A running total of your portfolio value is displayed under your balance, along with a net worth readout that sums balance and portfolio value. A passive income system pays out every few seconds, and an upgrade shop lets you spend currency to increase that rate.
+This project uses Vite and React to showcase the early MVP for the 404Cache stock market game. Prices update automatically and you can buy or sell a collection of **six** playful stocks to watch your balance change. Each stock sports its own emoji for quick recognition. A running total of your portfolio value is displayed under your balance, along with a net worth readout that sums balance and portfolio value. A passive income system pays out every few seconds, and an upgrade shop lets you spend currency to increase that rate or expand your personal stock limits.
 
 ## Data Persistence
 

--- a/public/upgrades.json
+++ b/public/upgrades.json
@@ -26,5 +26,26 @@
     "type": "unlock_market",
     "value": "cyber",
     "cost": 5000
+  },
+  {
+    "id": "limit_upgrade_1",
+    "name": "Buy Limit +5 I",
+    "type": "limit_up",
+    "value": 5,
+    "cost": 2000
+  },
+  {
+    "id": "limit_upgrade_2",
+    "name": "Buy Limit +5 II",
+    "type": "limit_up",
+    "value": 5,
+    "cost": 4000
+  },
+  {
+    "id": "limit_upgrade_3",
+    "name": "Buy Limit +5 III",
+    "type": "limit_up",
+    "value": 5,
+    "cost": 8000
   }
 ]

--- a/src/components/StockList.jsx
+++ b/src/components/StockList.jsx
@@ -1,6 +1,6 @@
 import StockCard from './StockCard';
 
-function StockList({ stocks, portfolio, balance, onBuy, onSell, limits, globalOwned, terminalMode }) {
+function StockList({ stocks, portfolio, balance, onBuy, onSell, limits, extraLimit = 0, globalOwned, terminalMode }) {
   const groups = {
     Stable: [],
     Volatile: [],
@@ -25,7 +25,9 @@ function StockList({ stocks, portfolio, balance, onBuy, onSell, limits, globalOw
             {list.map((stock) => {
               const limit = limits?.[stock.name];
               const remaining = limit ? limit.globalLimit - (globalOwned[stock.name] || 0) : Infinity;
-              const capReached = limit?.perPlayerLimit ? (portfolio[stock.name] || 0) >= limit.perPlayerLimit : false;
+              const capReached = limit?.perPlayerLimit
+                ? (portfolio[stock.name] || 0) >= limit.perPlayerLimit + extraLimit
+                : false;
               return (
                 <StockCard
                   key={stock.name}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -98,6 +98,10 @@ function Dashboard() {
 
 
   const [limits, setLimits] = useState({});
+  const [extraLimit, setExtraLimit] = useState(() => {
+    const stored = getItem<number>('extraLimit');
+    return stored ?? 0;
+  });
   const [globalOwned, setGlobalOwned] = useState(() => {
     const stored = getItem<Record<string, number>>('globalOwned');
     return stored ?? {};
@@ -226,6 +230,10 @@ function Dashboard() {
     setItem('unlockedMarkets', unlockedMarkets);
   }, [unlockedMarkets]);
 
+  useEffect(() => {
+    setItem('extraLimit', extraLimit);
+  }, [extraLimit]);
+
   const handlePurchaseUpgrade = (id) => {
     const upgrade = upgrades.find((u) => u.id === id);
     if (!upgrade) return;
@@ -247,6 +255,9 @@ function Dashboard() {
             setUnlockedMarkets((m) => [...m, upgrade.value]);
           }
           break;
+        case 'limit_up':
+          setExtraLimit((l) => l + upgrade.value);
+          break;
         default:
           break;
       }
@@ -266,7 +277,7 @@ function Dashboard() {
         addToast(`${stockName} is sold out`);
         return;
       }
-      if (cap.perPlayerLimit && owned >= cap.perPlayerLimit) {
+      if (cap.perPlayerLimit && owned >= cap.perPlayerLimit + extraLimit) {
         addToast(`You reached the limit for ${stockName}`);
         return;
       }
@@ -319,6 +330,7 @@ function Dashboard() {
     setHistory([]);
     setStocks(INITIAL_STOCKS.map((s) => ({ ...s })));
     setGlobalOwned({});
+    setExtraLimit(0);
     removeItem('balance');
     removeItem('portfolio');
     removeItem('passiveRate');
@@ -330,6 +342,7 @@ function Dashboard() {
     removeItem('loginStreak');
     removeItem('lastLoginDate');
     removeItem('globalOwned');
+    removeItem('extraLimit');
   };
 
   const portfolioValue = stocks.reduce((sum, stock) => {
@@ -432,6 +445,7 @@ function Dashboard() {
             onBuy={handleBuy}
             onSell={handleSell}
             limits={limits}
+            extraLimit={extraLimit}
             globalOwned={globalOwned}
             terminalMode={terminalMode}
           />


### PR DESCRIPTION
## Summary
- increase personal stock limits with new `limit_up` upgrades
- persist the buy limit boost in local storage
- reset limit boosts when resetting the game
- surface the limit boost in the stock list display
- mention the new upgrade in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f107b27e08329a727dad4d1e8a5ee